### PR TITLE
Correction de quelques coquilles dans intexgral-doc-fr.tex

### DIFF
--- a/doc/intexgral-doc-fr.tex
+++ b/doc/intexgral-doc-fr.tex
@@ -81,7 +81,7 @@
 
 \begin{abstract}
 
-Tandis que la composition d'intégrales est très fréquent en \LaTeX, cette dernière se révèle souvent peu pratique. Lorsque l'expression devient complexe, il devient alors difficile d'en modifier les différents éléments dans un code source peu lisible. Pour répondre à ce problème, le package \pkg{intexgral} met à disposition une macro centrale dont le seul argument est l'intégrande. Tout le reste (les bornes, les différentielles\dots) pourra aisément être modifié grâce à une interface \meta{clés = valeur}. Contrairement à la méthode classique, où l'utilisateur choisit l'ordre des bornes avec les charactères actifs \verb|_| et \verb|^|, le package a dû fixer une convention. Ainsi, pour les deux clés gérant les bornes qui seront présentées, l'entrée supposée sera \verb|_|\meta{borne inférieure}\verb|^|\meta{borne supérieure}. Ce package étant écrit en \pkg{expl3}, il dépend donc des packages \LaTeX3 \pkg{l3kernel} et \pkg{l3package}. De plus, \pkg{intexgral} utilise le package \pkg{derivative} afin de faciliter la manipulation de différentielles.
+Tandis que la composition d'intégrales est très fréquente en \LaTeX, cette dernière se révèle souvent peu pratique. Lorsque l'expression devient complexe, il devient alors difficile d'en modifier les différents éléments dans un code source peu lisible. Pour répondre à ce problème, le package \pkg{intexgral} met à disposition une macro centrale dont le seul argument est l'intégrande. Tout le reste (les bornes, les différentielles\dots) pourra aisément être modifié grâce à une interface \meta{clés = valeur}. Contrairement à la méthode classique, où l'utilisateur choisit l'ordre des bornes avec les caractères actifs \verb|_| et \verb|^|, le package a dû fixer une convention. Ainsi, pour les deux clés gérant les bornes qui seront présentées, l'entrée supposée sera \verb|_|\meta{borne inférieure}\verb|^|\meta{borne supérieure}. Ce package étant écrit en \pkg{expl3}, il dépend donc des packages \LaTeX3 \pkg{l3kernel} et \pkg{l3package}. De plus, \pkg{intexgral} utilise le package \pkg{derivative} afin de faciliter la manipulation de différentielles.
 
 \end{abstract}
 
@@ -206,7 +206,7 @@ La grande force de \texttt{limits} est qu'elle permet de spécifier les bornes d
   \begin{syntax}
     \meta{boolean}\hfill(défaut: false)
   \end{syntax}
-  Cette clé sépare les différentes variables de l'intégrales et les isole. Il est donc nécessaire de l'utiliser \emph{avant} \texttt{limits} afin que celle ci sache dans quel mode opérer. De plus, cette clé requiert que l'on indique comment séparer l'intégrande. Cette étape supplémentaire se réalise en suivant la même logique que pour les bornes, c'est-à-dire en utilisant le point-virgule. 
+  Cette clé sépare les différentes variables de l'intégrale et les isole. Il est donc nécessaire de l'utiliser \emph{avant} \texttt{limits} afin que celle ci sache dans quel mode opérer. De plus, cette clé requiert que l'on indique comment séparer l'intégrande. Cette étape supplémentaire se réalise en suivant la même logique que pour les bornes, c'est-à-dire en utilisant le point-virgule. 
 \end{function}
 
 \begin{codehigh}
@@ -254,7 +254,7 @@ Pour bien fonctionner, il est évident que les clés \texttt{limits} et \texttt{
 
 Les clés \texttt{limits} et \texttt{limits*} se révèlent très utiles lorsque l'expression finale d'une intégrale est déterminée (autrement dit, lorsque les bornes de chaque variable ont été définies). Cependant, cela couvre seulement\dots\ l'expression finale! Pour des cas plus généraux, elles sont relativement malcommodes. Pour composer une intégrale double sur une surface S, on devrait écrire \verb|limits={,;,S}|. Il va sans dire que c'est assez maladapté pour l'utilisateur et peu optimal pour le package. Par ailleurs, le glyphe ne serait pas correct. L'ensemble des clés à suivre propose donc une façon de modifier facilement le symbole intégrale et les bornes.
 
-\subsubsection{Séléctionner le symbole}
+\subsubsection{Sélectionner le symbole}
 
 \begin{function}{int-symb}
   \begin{syntax}
@@ -602,7 +602,7 @@ V_\textrm{sphère} =
   \begin{syntax}
     \marg{csname}
   \end{syntax}
-  Si vous utilisez un package définissant des symboles ne faisants pas partie d'\pkg{unicode-math}, vous pouvez les charger en utilisant la macro \cs{NewIntegralSymbol} dans le préambule. Il seront dès lors accessible avec la clé \texttt{int-symb}. L'argument devra prendre la forme d'une commande \emph{sans antislash}: par exemple \verb|NewIntegralSymbol{myint}|. Veuillez noter que \cs{NewIntegralSymbol} n'est qu'un moyen pour le package de reconnaître les symboles préexistants et leurs macros de façon interne. Ce n'est en rien une manière de créer un nouveau glyphe. Il en va de la responsabilité de l'utilisateur de charger les packages nécessaires pour que les symboles voulus soient définis.
+  Si vous utilisez un package définissant des symboles ne faisant pas partie d'\pkg{unicode-math}, vous pouvez les charger en utilisant la macro \cs{NewIntegralSymbol} dans le préambule. Il seront dès lors accessible avec la clé \texttt{int-symb}. L'argument devra prendre la forme d'une commande \emph{sans antislash}: par exemple \verb|NewIntegralSymbol{myint}|. Veuillez noter que \cs{NewIntegralSymbol} n'est qu'un moyen pour le package de reconnaître les symboles préexistants et leurs macros de façon interne. Ce n'est en rien une manière de créer un nouveau glyphe. Il en va de la responsabilité de l'utilisateur de charger les packages nécessaires pour que les symboles voulus soient définis.
 \end{function}
 
 \subsection{Retour sur les bornes}
@@ -611,16 +611,16 @@ V_\textrm{sphère} =
   \begin{syntax}
     \marg{mot-clé}\marg{bornes}
   \end{syntax}
-Il est courrant de devoir renseigner les même bornes dans une intégrale. Pour faciliter leur écriture, les clé(s) \texttt{limits(*)} accepte également un mot-clé désignant des bornes définies par l'un de ces quatre macros:
+Il est courrant de devoir renseigner les même bornes dans une intégrale. Pour faciliter leur écriture, les clé(s) \texttt{limits(*)} accepte également un mot-clé désignant des bornes définies par l'une de ces quatre macros:
 \end{function}
 \begin{itemize}
-  \item \cs{NewLimitsKeyword} crée un nouveau mot clé et émet une erreur s'il existe déjà.
-  \item \cs{RenewLimitsKeyword} redéfinit un mot clé et émet une erreur s'il n'existe pas déjà. 
-  \item \cs{ProvideLimitsKeyword} ne crée un nouveau mot clé que s'il n'existe pas déjà. Aucun message ne sera émis dans le cas échéant.
-  \item \cs{DeclareLimitsKeyword} crée un nouveau mot clé quoiqu'il en soit, écrasant toute définition préalable.
+  \item \cs{NewLimitsKeyword} crée un nouveau mot-clé et émet une erreur s'il existe déjà.
+  \item \cs{RenewLimitsKeyword} redéfinit un mot-clé et émet une erreur s'il n'existe pas déjà. 
+  \item \cs{ProvideLimitsKeyword} ne crée un nouveau mot-clé que s'il n'existe pas déjà. Aucun message ne sera émis dans le cas échéant.
+  \item \cs{DeclareLimitsKeyword} crée un nouveau mot-clé quoiqu'il en soit, écrasant toute définition préalable.
 \end{itemize}
 
-En reprenant l'un des exemples précédents, ont pourrait modifier l'expression de l'intégrale de la façon suivante:
+En reprenant l'un des exemples précédents, on pourrait modifier l'expression de l'intégrale de la façon suivante:
 
 \begin{codehigh}
 \integral[
@@ -667,7 +667,7 @@ En reprenant l'un des exemples précédents, ont pourrait modifier l'expression 
   \begin{syntax}
     \marg{mot-clé}\marg{différentielles}\oarg{jacobien}
   \end{syntax}
-De façon similaire, les mêmes groupes de différentielles réapparaissent souvent. On peut donc également définir des mots clés dont la liste est déjà prédéfinie (les variantes ont le même comportement). 
+De façon similaire, les mêmes groupes de différentielles réapparaissent souvent. On peut donc également définir des mots-clés dont la liste est déjà prédéfinie (les variantes ont le même comportement). 
 \end{function}
 
 La seule différence est que l'on peut en plus spécifier un jacobien. Ce dernier devra prendre la forme d'une clist. Ceci permet de pouvoir séparer le jacobien lorsque le mode \texttt{int-split} est activé. Son affichage est contrôlé par la clé \texttt{jacobian} expliquée précedemment.


### PR DESCRIPTION
Tout d'abord, super package ! Je propose quelques corrections dans la documentation, quelques petites coquilles repérées (par exemple dans le résumé, remplacé fréquent par fréquente et charactères par caractères). J'ai également changé quelques « mot clé » en « mot-clé », car dans le reste du document, c'est bien écrit sous cette forme. Raison pour laquelle j'ai changé également « mots clés » en « mots-clés ». Au tout début de la documentation, on lit « Publié 2025-07-26 », je pense qu'il serait mieux de lire « Publié le 26-07-2025 ». Ajouter le mot « le » sera simple. Changer le format de date un peu moins. Je ferai un autre pull request si je trouve un moyen simple d'y parvenir, à moins que vous y arrivez avant.